### PR TITLE
Unnecessary inputs for pure-python packages linting workflow

### DIFF
--- a/workflow-templates/hqs-ci-test-pure-python.yml
+++ b/workflow-templates/hqs-ci-test-pure-python.yml
@@ -11,10 +11,6 @@ jobs:
     with: 
       python_folder: "NAME_OF_TOP_LEVEL_PYTHON_FOLDER"
       linting_folder: "NAME_OF_PYTHON_FOLDER_TO_LINT"
-      # Run tests also on windows runners
-      windows: false
-      # Run tests also on macos runners
-      macos: true
 
   unittests:
     uses: HQSquantumsimulations/reusable_workflows/.github/workflows/reusable_tests_pure_python.yml@main


### PR DESCRIPTION
The reusable `reusable_linting_pure_python.yml` does not need windows and macos inputs.